### PR TITLE
Safe outside calls

### DIFF
--- a/contracts/test_contracts/DummyContract.t.sol
+++ b/contracts/test_contracts/DummyContract.t.sol
@@ -6,8 +6,14 @@ event PayableEvent(uint256 value, bytes data);
 
 contract DummyContract {
 
+    function doNothing() external payable {}
+
     function call(bytes calldata data) external {
         emit Event(data);
+    }
+
+    function callReturning(bytes calldata data) external payable returns (bytes memory) {
+        return data;
     }
 
     function callPayable(bytes calldata data) external payable {
@@ -21,6 +27,40 @@ contract DummyContract {
     function outOfGas() pure external {
         uint256 i;
         while(true) i++;
+    }
+
+    function burnVariableCycles(uint256 iterations) external payable {
+        assembly {
+            for { } gt(iterations, 0) { iterations := sub(iterations, 1) } {}
+        }
+    }
+
+    function burn10k() external payable {
+        assembly {
+            let iterations := 277
+            for { } gt(iterations, 0) { iterations := sub(iterations, 1) } {}
+        }
+    }
+
+    function burn100k() external payable {
+        assembly {
+            let iterations := 2849
+            for { } gt(iterations, 0) { iterations := sub(iterations, 1) } {}
+        }
+    }
+
+    function burn1m() external payable {
+        assembly {
+            let iterations := 28565
+            for { } gt(iterations, 0) { iterations := sub(iterations, 1) } {}
+        }
+    }
+
+    function burn5m() external payable {
+        assembly {
+            let iterations := 142857
+            for { } gt(iterations, 0) { iterations := sub(iterations, 1) } {}
+        }
     }
 
 }

--- a/contracts/utils/ContractCallUtils.sol
+++ b/contracts/utils/ContractCallUtils.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+library ContractCallUtils {
+
+    //Executes a call strictly with the provided gasLimit, if there is not enough gas left
+    // in the current execution (less than provided gasLimit). It reverts without calling the
+    // contract
+    function safeCall(
+        address target, uint256 value, bytes memory data, uint256 gasLimit
+    ) internal returns (bool success, bytes memory returnData) {
+        //Assert the gasLimit is less than 2^248, so we can safely do the 63/64 arithmetic with it
+        require(gasLimit < 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, "safeCall: gasLimit too high");
+
+        assembly ("memory-safe") {
+            //The call to extcodesize also warms-up the target, so we can use warm access
+            // costs in the subsequent approximations
+            switch extcodesize(target)
+            case 0 {
+                //Target has no code, hence should consume 0 gas and only the intrinsic call
+                // opcode costs is deducted, additionally we can be sure that no data is returned
+                // so we can safely ignore all the return data
+                success := call(0, target, value, add(data, 0x20), mload(data), 0, 0)
+            }
+            default {
+                //Target has some code, hence we must make sure that we can forward the required
+                // gasLimit to the contract
+                //For this we need to get the cost of the CALL opcode intrinsic cost, we need to
+                // consider that since extcodesize returned >0, the target is is definitely initialized
+                // and we do a warm access now, since the extcodesize warmed up the contract
+                //Checks are based on https://www.evm.codes/?fork=prague#f1
+                /*
+                    The different costs are:
+                    - code_execution_cost is the cost of the called code execution (limited by the gas parameter).
+                    - If address is warm, then address_access_cost is 100, otherwise it is 2600. See section access sets.
+                    - If value is not 0, then positive_value_cost is 9000. In this case there is also a call stipend that is given to make sure that a basic fallback function can be called. 2300 is thus removed from the cost, and also added to the gas input.
+                    - If value is not 0 and the address given points to an empty account, then value_to_empty_account_cost is 25000. An account is empty if its balance is 0, its nonce is 0 and it has no code.
+                 */
+                let callIntrinsicCost := sub(
+                    9100, //This is the cost if value is positive (100 gas for warm access + 9000 gas for value transfer)
+                    mul(iszero(value), 9000) //If the value is zero we deduct 9000 gas for value transfer, leaving just 100 gas cost
+                )
+
+                let requiredGas := add(
+                    div(shl(6, gasLimit) /*mul(gasLimit, 64)*/, 63), // 63/64 eip-150 rule
+                    add(
+                        callIntrinsicCost, //Additional overhead due to intrinsic CALL costs
+                        50 //Additional buffer for stack manipulation before CALL
+                    )
+                )
+
+                //This part is not memory-safe, but it's fine because it's reverting
+                if lt(gas(), requiredGas) {
+                    //Write function selector: Error(string)
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    //Offset to string (always 32)
+                    mstore(0x04, 32)
+                    //String length: 26
+                    mstore(0x24, 26)
+                    //Error message
+                    mstore(0x44, "safeCall(): not enough gas")
+                    revert(0, 0x64)
+                }
+                
+                //Execute low-level call
+                success := call(gasLimit, target, value, add(data, 0x20), mload(data), 0, 0)
+                
+                //Copy the return data
+                let returnDataSize := returndatasize()
+
+                //Get free memory pointer
+                let freeMemoryPointer := mload(0x40)
+                returnData := freeMemoryPointer
+
+                //Prepend the return data size to make it a valid bytes memory layout
+                mstore(freeMemoryPointer, returnDataSize)
+                freeMemoryPointer := add(freeMemoryPointer, 0x20)
+                //Store returned data
+                returndatacopy(freeMemoryPointer, 0, returnDataSize)
+                
+                //Adjust free memory pointer with returned data size
+                mstore(0x40, add(freeMemoryPointer, returnDataSize))
+            }
+        }
+    }
+
+    //Executes the call by forwarding all the available gas and asserts that the
+    // sender didn't intentionally use low gas limit to starve out the called
+    // contract and make it run out of gas. This can open up gas-dependendnt
+    // branching. I.e. a malicious actor can intentionally let the contract
+    // call run out of gas, when it would've suceeded otherwise
+    //WARNING: This doesn't protect against contracts which spend infinite gas!!! And
+    // this would always revert for such contracts!
+    function safeCall(
+        address target, uint256 value, bytes memory data
+    ) internal returns (bool success, bytes memory returnData) {
+        //We leverage the EIP-150 63/64 rule, if the post-call gas is close 
+        // to 1/64 of the original we rule that there is a malicously set
+        // gas limit by the origin, which attempted to make the external call
+        // maliciously fail by running out of gas
+        
+        assembly ("memory-safe") {
+            //The call to extcodesize also warms-up the target, so we can use warm access
+            // costs in the subsequent approximations
+            switch extcodesize(target)
+            case 0 {
+                //Target has no code, hence should consume 0 gas and only the intrinsic call
+                // opcode costs is deducted, additionally we can be sure that no data is returned
+                // so we can safely ignore all the return data
+                success := call(0, target, value, add(data, 0x20), mload(data), 0, 0)
+            }
+            default {
+                //Save gas snapshot before execution
+                let preExecutionGas := gas()
+                
+                //Execute low-level call, with all the available gas
+                success := call(
+                    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, 
+                    target, value, add(data, 0x20), mload(data), 0, 0
+                )
+
+                //Capture remaining gas right after execution
+                let postExecutionGas := gas()
+                
+                //Calculate intrinsic cost of the CALL opcode
+                let callIntrinsicCost := sub(
+                    9100, //This is the cost if value is positive (100 gas for warm access + 9000 gas for value transfer)
+                    mul(iszero(value), 9000) //If the value is zero we deduct 9000 gas for value transfer, leaving just 100 gas cost
+                )
+
+                //This part is not memory-safe, but it's fine because it's reverting
+                //Compare the pre-execution and post-execution gas
+                //Use multiplier of 32 (instead of 64), to provide some reasonable buffer, and also
+                // add 50 gas on top as a buffer for possible stack-shifting operations before CALL
+                // opcode is executed
+                if lt(
+                    add(
+                        shl(5, postExecutionGas), //Same as: mul(postExecutionGas, 32)
+                        add(50, callIntrinsicCost) //50 gas buffer + intrinsic call gas cost
+                    ),
+                    preExecutionGas
+                ) {
+                    //Write function selector: Error(string)
+                    mstore(0, 0x08c379a000000000000000000000000000000000000000000000000000000000)
+                    //Offset to string (always 32)
+                    mstore(0x04, 32)
+                    //String length: 26
+                    mstore(0x24, 26)
+                    //Error message
+                    mstore(0x44, "safeCall(): not enough gas")
+                    revert(0, 0x64)
+                }
+
+                //Copy the call return data
+                //Get free memory pointer
+                let freeMemoryPointer := mload(0x40)
+                returnData := freeMemoryPointer
+
+                //Prepend the return data size to make it a valid bytes memory layout
+                let returnDataSize := returndatasize()
+                mstore(freeMemoryPointer, returnDataSize)
+                freeMemoryPointer := add(freeMemoryPointer, 0x20)
+
+                //Store returned data
+                returndatacopy(freeMemoryPointer, 0, returnDataSize)
+                
+                //Adjust free memory pointer with returned data size
+                mstore(0x40, add(freeMemoryPointer, returnDataSize))
+            }
+        }
+    }
+}

--- a/contracts/utils/ContractCallUtils.t.sol
+++ b/contracts/utils/ContractCallUtils.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.28;
+
+import "./ContractCallUtils.sol";
+
+contract ContractCallUtilsWrapper {
+
+    event ExecutionResult(bool indexed success, bytes callError);
+    
+    receive() external payable {}
+
+    function safeCall(
+        address target, uint256 value, bytes memory data, uint256 gasLimit
+    ) external {
+        (bool success, bytes memory callError) = ContractCallUtils.safeCall(target, value, data, gasLimit);
+        emit ExecutionResult(success, callError);
+    }
+
+    function safeCallNoEmit(
+        address target, uint256 value, bytes memory data, uint256 gasLimit
+    ) external {
+        ContractCallUtils.safeCall(target, value, data, gasLimit);
+    }
+
+    function safeCall(
+        address target, uint256 value, bytes memory data
+    ) external {
+        (bool success, bytes memory result) = ContractCallUtils.safeCall(target, value, data);
+        emit ExecutionResult(success, result);
+    }
+
+    function safeCallNoEmit(
+        address target, uint256 value, bytes memory data
+    ) external {
+        ContractCallUtils.safeCall(target, value, data);
+    }
+
+    function standardCall(
+        address target, uint256 value, bytes memory data
+    ) external {
+        (bool success, bytes memory result) = target.call{value: value, gas: gasleft()}(data);
+        emit ExecutionResult(success, result);
+    }
+
+    function standardCallNoEmit(
+        address target, uint256 value, bytes memory data
+    ) external {
+        target.call{value: value, gas: gasleft()}(data);
+    }
+
+}

--- a/test/unit/test_contracts/DummyContract.ts
+++ b/test/unit/test_contracts/DummyContract.ts
@@ -1,0 +1,60 @@
+import {
+    loadFixture,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { assert} from "chai";
+import hre from "hardhat";
+
+async function deploy() {
+    const DummyContract = await hre.ethers.getContractFactory("DummyContract");
+    const dummyContract = await DummyContract.deploy();
+
+    const [account1] = await hre.ethers.getSigners();
+
+    return {account1, dummyContract};
+}
+
+describe("ContractCallUtils: strictCall", function () {
+    it("Test gas burner (10k)", async function () {
+        const {account1, dummyContract} = await loadFixture(deploy);
+
+        const unsignedTx = await dummyContract.burn10k.populateTransaction();
+        const tx = await account1.sendTransaction(unsignedTx);
+        const receipt = await tx.wait();
+        const gasUsed = Number(receipt.gasUsed) - 21_000;
+        assert.isAtLeast(gasUsed, 10_000 - 50);
+        assert.isAtMost(gasUsed, 10_000 + 50);
+    });
+
+    it("Test gas burner (100k)", async function () {
+        const {account1, dummyContract} = await loadFixture(deploy);
+
+        const unsignedTx = await dummyContract.burn100k.populateTransaction();
+        const tx = await account1.sendTransaction(unsignedTx);
+        const receipt = await tx.wait();
+        const gasUsed = Number(receipt.gasUsed) - 21_000;
+        assert.isAtLeast(gasUsed, 100_000 - 50);
+        assert.isAtMost(gasUsed, 100_000 + 50);
+    });
+
+    it("Test gas burner (1M)", async function () {
+        const {account1, dummyContract} = await loadFixture(deploy);
+
+        const unsignedTx = await dummyContract.burn1m.populateTransaction();
+        const tx = await account1.sendTransaction(unsignedTx);
+        const receipt = await tx.wait();
+        const gasUsed = Number(receipt.gasUsed) - 21_000;
+        assert.isAtLeast(gasUsed, 1_000_000 - 100);
+        assert.isAtMost(gasUsed, 1_000_000 + 100);
+    });
+
+    it("Test gas burner (5M)", async function () {
+        const {account1, dummyContract} = await loadFixture(deploy);
+        
+        const unsignedTx = await dummyContract.burn5m.populateTransaction();
+        const tx = await account1.sendTransaction(unsignedTx);
+        const receipt = await tx.wait();
+        const gasUsed = Number(receipt.gasUsed) - 21_000;
+        assert.isAtLeast(gasUsed, 5_000_000 - 500);
+        assert.isAtMost(gasUsed, 5_000_000 + 500);
+    });
+});

--- a/test/unit/utils/ContractCallUtils.ts
+++ b/test/unit/utils/ContractCallUtils.ts
@@ -1,0 +1,926 @@
+import {
+    loadFixture,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { assert, expect } from "chai";
+import hre from "hardhat";
+import { randomAddress } from "../../utils/evm/utils";
+
+async function deploy() {
+    const ContractCallUtilsWrapper = await hre.ethers.getContractFactory("ContractCallUtilsWrapper");
+    const contract = await ContractCallUtilsWrapper.deploy();
+
+    const DummyContract = await hre.ethers.getContractFactory("DummyContract");
+    const dummyContract = await DummyContract.deploy();
+
+    const [account1] = await hre.ethers.getSigners();
+
+    return {account1, contract, dummyContract};
+}
+
+describe("ContractCallUtils: safeCall (with gasLimit)", function () {
+    it("Valid contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.call.populateTransaction("0x01020304");
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            0,
+            data,
+            10_000
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        await expect(promise).to.emit(dummyContract, "Event").withArgs("0x01020304");
+    });
+
+    it("Valid contract call with return data", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callReturning.populateTransaction("0x01020304");
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            0,
+            data,
+            10_000
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(
+            true,
+            "0x"+
+            "0000000000000000000000000000000000000000000000000000000000000020"+
+            "0000000000000000000000000000000000000000000000000000000000000004"+
+            "0102030400000000000000000000000000000000000000000000000000000000"
+        );
+    });
+
+    it("Valid payable contract call", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callPayable.populateTransaction("0x01020304");
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000n});
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            1_000,
+            data,
+            10_000
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        await expect(promise).to.emit(dummyContract, "PayableEvent").withArgs(1000, "0x01020304");
+    });
+
+    it("Valid contract payable call with return data", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callReturning.populateTransaction("0x0102030405060708");
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000n});
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            1_000,
+            data,
+            10_000
+        );
+
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(
+            true,
+            "0x"+
+            "0000000000000000000000000000000000000000000000000000000000000020"+
+            "0000000000000000000000000000000000000000000000000000000000000008"+
+            "0102030405060708000000000000000000000000000000000000000000000000"
+        );
+    });
+
+    it("Valid reverting contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callRevert.populateTransaction("Hello");
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            0,
+            data,
+            10_000
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(false, "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000548656c6c6f000000000000000000000000000000000000000000000000000000");
+    });
+
+    it("Valid out of gas contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.outOfGas.populateTransaction();
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to,
+            0,
+            data,
+            10_000 //Use too little gas
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(false, "0x");
+    });
+
+    it("Valid contract doesn't exist", async function () {
+        const {contract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            randomAddress(),
+            0,
+            "0x01020304",
+            10_000
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+
+        const txResult = await promise;
+        
+        //Now we want to check that the gas forwarded in the call is 0
+        //Get the tx trace
+        const trace = await hre.ethers.provider.send("debug_traceTransaction", [txResult.hash]);
+        //Get the frame of the first CALL opcode
+        const callFrame = trace.structLogs.find((val: any) => val.op==="CALL");
+        assert.strictEqual(callFrame.gasCost, 100n, "Invalid CALL opcode gas cost, should be 100 gas!")
+    });
+
+    it("Invalid call with too little gas", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            await dummyContract.getAddress(),
+            0,
+            "0x01020304", //Any data
+            10_000,
+            {
+                gasLimit: 21_000 + 10_000
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+    });
+
+    it("Invalid call with too little gas (value>0, empty account)", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            randomAddress(), //Target has to be an empty account
+            1_000, //Non-zero value
+            "0x01020304", //Any data
+            10_000, //Gas to forward is ignored since target is not contract (has no code)
+            {
+                //Now this requires an intrinsic CALL gas of at least 34300
+                gasLimit: 21_000 + 34_300
+            }
+        );
+        //Should just run out of gas itself, since it has not enough gas to cover
+        // call opcode intrinsic gas cost
+        await expect(promise).to.be.revertedWithoutReason();
+    });
+
+    it("Valid call with enough gas (value>0, empty account)", async function () {
+        const {account1, contract} = await loadFixture(deploy);
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000});
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            randomAddress(), //Target has to be an empty account
+            1_000, //Non-zero value
+            "0x01020304", //Any data
+            10_000, //Gas to forward is ignored since target is not contract (has no code)
+            {
+                //Now this requires an intrinsic CALL gas of at least 34100
+                gasLimit: 21_000 + 34_100 + 6_000
+            }
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        
+        const txResult = await promise;
+        
+        //Now we want to check that the gas forwarded in the call is 0
+        //Get the tx trace
+        const trace = await hre.ethers.provider.send("debug_traceTransaction", [txResult.hash]);
+        //Get the frame of the first CALL opcode
+        const callFrame = trace.structLogs.find((val: any) => val.op==="CALL");
+        //Intrinsic gas cost of the CALL opcode in this case is 34100 gas (100 gas warm access + 9000 gas transfer + 25000 empty account transfer)
+        assert.strictEqual(callFrame.gasCost, 34100n, "Invalid CALL opcode gas cost, should be 34100 gas!")
+    });
+
+    it("Invalid call with too little gas (value>0, non-empty account - EOA)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            account1.address, //Target has is account1 (non-empty EOA, has balance)
+            1_000, //Non-zero value
+            "0x01020304", //Any data
+            10_000, //Gas to forward is ignored since target is not contract (has no code)
+            {
+                //Now this requires an intrinsic CALL gas of at least 9100
+                gasLimit: 21_000 + 9_100
+            }
+        );
+        await expect(promise).to.be.revertedWithoutReason();
+    });
+
+    it("Valid call (value>0, non-empty account - EOA)", async function () {
+        const {account1, contract} = await loadFixture(deploy);
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000});
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            account1.address, //Target is account1 (non-empty EOA, has balance)
+            1_000, //Non-zero value
+            "0x01020304", //Any data
+            10_000, //Gas to forward is ignored since target is not contract (has no code)
+            {
+                //Now this requires an intrinsic CALL gas of at least 9100 + some additional gas for processing stuff
+                gasLimit: 21_000 + 9_100 + 5_000
+            }
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        
+        const txResult = await promise;
+        
+        //Now we want to check that the gas forwarded in the call is 0
+        //Get the tx trace
+        const trace = await hre.ethers.provider.send("debug_traceTransaction", [txResult.hash]);
+        //Get the frame of the first CALL opcode
+        const callFrame = trace.structLogs.find((val: any) => val.op==="CALL");
+        //Intrinsic gas cost of the CALL opcode in this case is 9100 gas (100 gas warm access + 9000 gas transfer)
+        assert.strictEqual(callFrame.gasCost, 9100n, "Invalid CALL opcode gas cost, should be 9100 gas!")
+    });
+
+    it("Invalid call with too little gas (value>0, non-empty account - contract)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            await dummyContract.getAddress(), //Target is dummy contract (non-empty contract with code)
+            1_000, //Non-zero value
+            "0x01020304", //Any data
+            10_000,
+            {
+                //Now this requires an intrinsic CALL gas of at least 9100
+                gasLimit: 21_000 + 9_100 + 10_000
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+    });
+
+    it("Valid call with enough gas (value>0, non-empty account - contract)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000});
+
+        const {to, data} = await dummyContract.callPayable.populateTransaction("0x01020304");
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to, //Target is dummy contract (non-empty contract with code)
+            1_000, //Non-zero value
+            data,
+            10_000,
+            {
+                //Now this requires an intrinsic CALL gas of at least 9100 + 10000 gas forward + some additional gas for processing stuff
+                gasLimit: 21_000 + 9_100 + 10_000 + 6_000
+            }
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        await expect(promise).to.emit(dummyContract, "PayableEvent").withArgs(1000, "0x01020304");
+        
+        const txResult = await promise;
+        
+        //Now we want to check that the gas forwarded in the call is exactly 10_000
+        //Get the tx trace
+        const trace = await hre.ethers.provider.send("debug_traceTransaction", [txResult.hash]);
+        //Get the frame of the first CALL opcode
+        const callFrameIndex = trace.structLogs.findIndex((val: any) => val.op==="CALL");
+        //Next frame is in the context of the called contract
+        const nextFrame = trace.structLogs[callFrameIndex + 1];
+        //Intrinsic gas cost of the CALL opcode in this case is 9100 gas (100 gas warm access + 9000 gas transfer)
+        assert.strictEqual(trace.structLogs[callFrameIndex].gasCost, 10_000n + 9100n, "Invalid CALL opcode gas cost, should be 19100 gas!");
+        //Assert gas forward is indeed exactly 10k + 2300 stipend because we are transfering value
+        assert.strictEqual(nextFrame.gas, 10_000n + 2_300n, "Invalid amount of gas forwarded, should be 10000 + 2300 gas!");
+    });
+
+    it("Valid call with possible EIP-150 exploit", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.burn5m.populateTransaction();
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to, //Target is dummy contract (non-empty contract with code)
+            0, //Zero value
+            data,
+            5_050_000,
+            {
+                //Now this requires an intrinsic CALL gas of at least 2600 + 5050000 gas forward + some additional gas for processing stuff
+                gasLimit: 21_000 + 2_600 + Math.floor(5_050_000 * 64 / 63) + 5_500
+            }
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+    it("Invalid call with possible EIP-150 exploit", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.burn5m.populateTransaction();
+        const promise = contract["safeCall(address,uint256,bytes,uint256)"](
+            to, //Target is dummy contract (non-empty contract with code)
+            0, //Zero value
+            data,
+            5_050_000,
+            //Attempt to call with lower gas limit that what has been defined in the params
+            {
+                //Now this requires an intrinsic CALL gas of at least 2600 + 5050000 gas forward (plus some additional gas because of 63/64 rule)
+                //  + some additional gas for processing stuff
+                gasLimit: 21_000 + 2_600 + Math.floor(5_050_000 * 64 / 63)
+            }
+        );
+        await expect(promise).to.be.rejectedWith("safeCall(): not enough gas");
+    });
+
+    //This test verifies the consistency of the ContractCallUtils implementation. It makes
+    // sure that the gasleft() check triggers before forwarded gas were to be decreased
+    // from it's desired value
+    it("Check consistency (contract calls)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        async function checkConsistency(to: string, data: string, value: bigint) {
+            const callIntrinsicCost = value===0n ? 100n : 9_100n;
+
+            const attemptCall = async (gasLimit: bigint, txGasLimit: bigint) => {
+                try {
+                    await contract["safeCallNoEmit(address,uint256,bytes,uint256)"](
+                        //Have to use random addresses with no zero bytes, such that
+                        // the calldata gas cost stays the same
+                        to,
+                        value,
+                        data,
+                        gasLimit,
+                        {
+                            gasLimit: txGasLimit
+                        }
+                    );
+                    return true;
+                } catch(e: any) {
+                    const _e = e as Error;
+                    if(_e.message.includes("safeCall(): not enough gas")) return false;
+                    if(_e.message.includes("Transaction ran out of gas")) return false;
+                    throw e;
+                }
+            }
+
+            const binarySearchMinimumTxGas = async (gasLimit: bigint) => {
+                let bottomValue = 21_000n //Base transaction gas
+                    + 2_600n //extcodesize() gas cost
+                    + callIntrinsicCost //intrinsic cost of the CALL opcode
+                    + (gasLimit * 64n / 63n); //Forwarded gas, considering the eip150 63/64 rule
+                let topValue = bottomValue + 6_000n; //Additional buffer
+
+                while (bottomValue <= topValue) {
+                    const mid = (bottomValue + topValue) / 2n;
+                    const success = await attemptCall(gasLimit, mid);
+
+                    if (success) {
+                        //Still success, we can decrease the top value
+                        topValue = mid - 1n;
+                    } else {
+                        //Not successful, gas needs to be increased
+                        bottomValue = mid + 1n;
+                    }
+                }
+
+                //Extract minimum required tx gas for the gasleft() test to be passed
+                const minimumRequiredTxGas = bottomValue;
+                //Double-check that minimum required tx gas indeed leads to successful tx
+                assert.isTrue(await attemptCall(gasLimit, minimumRequiredTxGas));
+                //One less gas and it fails
+                assert.isFalse(await attemptCall(gasLimit, minimumRequiredTxGas - 1n));
+
+                return minimumRequiredTxGas;
+            }
+
+            const gasLimits = [];
+
+            for(let i=162;i<1_500;i+=100) gasLimits.push(BigInt(i));
+            for(let i=1_500;i<15_000;i+=1_000) gasLimits.push(BigInt(i));
+            for(let i=15_000;i<150_000;i+=10_000) gasLimits.push(BigInt(i));
+            for(let i=150_000;i<1_500_000;i+=100_000) gasLimits.push(BigInt(i));
+            for(let i=1_500_000;i<29_000_000n;i+=1_000_000) gasLimits.push(BigInt(i));
+
+            for(let gasLimit of gasLimits) {
+                //This is the absolute minimum gas that the tx needs to still pass the
+                // internal gasleft() check, one less gas will make the tx revert 
+                const minimumRequiredTxGas = await binarySearchMinimumTxGas(gasLimit);
+                
+                const result = await contract["safeCallNoEmit(address,uint256,bytes,uint256)"](
+                    //Have to use random addresses with no zero bytes, such that
+                    // the calldata gas cost stays the same
+                    to,
+                    value,
+                    data,
+                    gasLimit,
+                    {
+                        gasLimit: minimumRequiredTxGas
+                    }
+                );
+
+                //Now we want to check that the gas forwarded to the other contract is indeed
+                // equal to the `gasLimit`
+                //Get the tx trace
+                const trace = await hre.ethers.provider.send("debug_traceTransaction", [result.hash]);
+                //Get the frame index of the first CALL opcode
+                const callFrameIndex = trace.structLogs.findIndex((val: any) => val.op==="CALL");
+                //Next frame is the first opcode of the called contract
+                const nextFrame = trace.structLogs[callFrameIndex+1];
+                //Check if that really is the case by checking the depth
+                assert.strictEqual(nextFrame.depth, 2, "Needs to be a contract call!");
+                //We can check the remaining gas there, it should always be equal to gasLimit
+                if(value > 0n) {
+                    //Add a transfer stipend of 2300 gas when value is non-zero
+                    assert.strictEqual(nextFrame.gas, gasLimit + 2_300n, "Full gas not forwarded");
+                } else {
+                    assert.strictEqual(nextFrame.gas, gasLimit, "Full gas not forwarded");
+                }
+            }
+        }
+
+        //Make sure contract has enough balance
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000_000_000n});
+
+        //This needs at minimum 162 gas!
+        const {to, data} = await dummyContract.doNothing.populateTransaction();
+        //Check consistency when calling existing contract without amount
+        await checkConsistency(to, data, 0n);
+        //Check consistency when calling existing contract with amount
+        await checkConsistency(to, data, 1_000n);
+    });
+
+});
+
+
+describe("ContractCallUtils: safeCall (no gasLimit - forward all)", function () {
+    it("Valid contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.call.populateTransaction("0x01020304");
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        await expect(promise).to.emit(dummyContract, "Event").withArgs("0x01020304");
+    });
+
+    it("Valid contract call with return data", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callReturning.populateTransaction("0x01020304");
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(
+            true,
+            "0x"+
+            "0000000000000000000000000000000000000000000000000000000000000020"+
+            "0000000000000000000000000000000000000000000000000000000000000004"+
+            "0102030400000000000000000000000000000000000000000000000000000000"
+        );
+    });
+
+    it("Valid payable contract call", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callPayable.populateTransaction("0x01020304");
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000n});
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            1_000,
+            data
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+        await expect(promise).to.emit(dummyContract, "PayableEvent").withArgs(1000, "0x01020304");
+    });
+
+    it("Valid payable call with return data", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callReturning.populateTransaction("0x010203040506");
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000n});
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            1_000,
+            data
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(
+            true,
+            "0x"+
+            "0000000000000000000000000000000000000000000000000000000000000020"+
+            "0000000000000000000000000000000000000000000000000000000000000006"+
+            "0102030405060000000000000000000000000000000000000000000000000000"
+        );
+    });
+
+    it("Valid reverting contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.callRevert.populateTransaction("Hello");
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(false, "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000548656c6c6f000000000000000000000000000000000000000000000000000000");
+    });
+
+    it("Valid out of gas contract call", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        const {to, data} = await dummyContract.outOfGas.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since outOfGas
+        // will burn everything)
+        await contract.standardCall(
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 200_000
+            }
+        );
+
+        //With safe call, this will actually revert!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data,
+            {
+                gasLimit: 21_000 + 200_000
+            }
+        );
+        //Manifests itself as a safeCall(): not enough gas
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+    });
+
+    it("Valid contract doesn't exist", async function () {
+        const {contract} = await loadFixture(deploy);
+
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            randomAddress(),
+            0,
+            "0x01020304"
+        );
+        await expect(promise).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+    it("Call 1M gas burner", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        //Check that burn1m really needs more than 200k gas
+        await expect(dummyContract.burn1m({gasLimit: 21_000 + 200_000})).to.be.revertedWithoutReason();
+
+        const {to, data} = await dummyContract.burn1m.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since burn1m
+        // costs around 1M gas to execute)
+        await expect(contract.standardCall(
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 200_000
+            }
+        )).to.emit(contract, "ExecutionResult").withArgs(false, "0x"); //Reverted due to out of gas!
+
+        //With safe call, this throws, because not enough gas is forwarded!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 200_000
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+
+        //Call with enough gas works through safeCall now!
+        const promise2 = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 1_050_000 //Add 5% buffer on top
+            }
+        );
+        await expect(promise2).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+    it("Call 100k gas burner", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        //Check that burn1m really needs more than 200k gas
+        await expect(dummyContract.burn100k({gasLimit: 21_000 + 95_000})).to.be.revertedWithoutReason();
+
+        const {to, data} = await dummyContract.burn100k.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since burn100k
+        // costs around 100k gas to execute)
+        await contract.standardCallNoEmit(
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 95_000 //Use 5% too little
+            }
+        );
+
+        //With safe call, this throws, because not enough gas is forwarded!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 95_000 //Use 5% too little
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+
+        //Call with enough gas works through safeCall now!
+        const promise2 = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 105_000 //Add 5% buffer on top
+            }
+        );
+        await expect(promise2).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+    it("Call 100k gas burner (with value)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        //Check that burn1m really needs more than 200k gas
+        await expect(dummyContract.burn100k({gasLimit: 21_000 + 95_000})).to.be.revertedWithoutReason();
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000});
+
+        const {to, data} = await dummyContract.burn100k.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since burn100k
+        // costs around 100k gas to execute)
+        await contract.standardCallNoEmit(
+            to,
+            1_000,
+            data, //Any data
+            {
+                //Use 5% too little (9,100 gas is an intrinsic cost of CALL opcode)
+                gasLimit: 21_000 + 9_100 + 95_000
+            }
+        );
+
+        //With safe call, this throws, because not enough gas is forwarded!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            1_000,
+            data, //Any data
+            {
+                //Use 5% too little (9,100 gas is an intrinsic cost of CALL opcode,
+                // 2,700 required for balance and extcodesize checks)
+                gasLimit: 21_000 + 2_700 + 9_100 + 95_000
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+
+        //Call with enough gas works through safeCall now!
+        const promise2 = contract["safeCall(address,uint256,bytes)"](
+            to,
+            1_000,
+            data, //Any data
+            {
+                //Add 5% buffer on top
+                gasLimit: 21_000 + 2_700 + 9_100 + 105_000
+            }
+        );
+        await expect(promise2).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+    it("Call 10k gas burner", async function () {
+        const {contract, dummyContract} = await loadFixture(deploy);
+
+        //Check that burn1m really needs more than 200k gas
+        await expect(dummyContract.burn10k({gasLimit: 21_000 + 9_500})).to.be.revertedWithoutReason();
+
+        const {to, data} = await dummyContract.burn10k.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since burn10k
+        // costs around 10k gas to execute)
+        await contract.standardCallNoEmit(
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 9_500 //Use 5% too little
+            }
+        );
+
+        //With safe call, this throws, because not enough gas is forwarded!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 9_500 //Use 5% too little
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+
+        //Call with enough gas works through safeCall now!
+        const promise2 = contract["safeCall(address,uint256,bytes)"](
+            to,
+            0,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 2_600 + 10_500 + 4_000 //Add 5% buffer on top + additional 4k for event emitting
+            }
+        );
+        await expect(promise2).to.emit(contract, "ExecutionResult").withArgs(true, "0x");
+    });
+
+
+    it("Call 10k gas burner (with value)", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        //Check that burn10k really needs more than 10k gas
+        await expect(dummyContract.burn10k({gasLimit: 21_000 + 9_500})).to.be.revertedWithoutReason();
+
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000});
+
+        const {to, data} = await dummyContract.burn10k.populateTransaction();
+
+        //This should just pass with a regular call, reverting inside with out of gas (since burn10k
+        // costs around 10k gas to execute)
+        await contract.standardCallNoEmit(
+            to,
+            1_000,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 9_100 + 9_500 //Use 5% too little
+            }
+        );
+
+        //With safe call, this throws, because not enough gas is forwarded!
+        const promise = contract["safeCall(address,uint256,bytes)"](
+            to,
+            1_000,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 9_100 + 1_900 + 9_500 //Use 5% too little
+            }
+        );
+        await expect(promise).to.be.revertedWith("safeCall(): not enough gas");
+
+        //Call with enough gas works through safeCall now!
+        //We can indirectly observe inner call being successful through balance changes
+        const preBalance = await account1.provider.getBalance(await contract.getAddress());
+        
+        //WTF is this about now? Reverts with 'function returned an unexpected amount of data'
+        const tx = await contract["safeCallNoEmit(address,uint256,bytes)"](
+            to,
+            1_000,
+            data, //Any data
+            {
+                gasLimit: 21_000 + 9_100 + 10_500 + 1_900 //Add 5% buffer on top + additional 2k gas for processing
+            }
+        );
+        const postBalance = await account1.provider.getBalance(await contract.getAddress());
+        assert.strictEqual(preBalance - postBalance, 1_000n);
+
+        const receipt = await tx.wait();
+    });
+
+    //This test verifies the consistency of the ContractCallUtils implementation. It makes
+    // sure that the implemented check triggers before all the 63/64 of the gas is forwarded
+    // to the contract
+    it("Check consistency (contract calls) - calling incrementally more expensive contracts with and without value", async function () {
+        const {account1, contract, dummyContract} = await loadFixture(deploy);
+
+        async function checkConsistency(value: bigint) {
+            const callIntrinsicCost = value===0n ? 100n : 9100n;
+            
+            const attemptCall = async (to: string, data: string, txGasLimit: bigint, strictErrMessage?: boolean) => {
+                try {
+                    await contract["safeCallNoEmit(address,uint256,bytes)"](
+                        //Have to use random addresses with no zero bytes, such that
+                        // the calldata gas cost stays the same
+                        to,
+                        value,
+                        data,
+                        {
+                            gasLimit: txGasLimit
+                        }
+                    );
+                    return true;
+                } catch(e: any) {
+                    const _e = e as Error;
+                    if(_e.message.includes("safeCall(): not enough gas")) return false;
+                    if(!strictErrMessage && _e.message.includes("Transaction ran out of gas")) return false;
+                    throw e;
+                }
+            }
+
+            const binarySearchMinimumTxGas = async (to: string, data: string, gasLimit: bigint) => {                
+                let bottomValue = 21_000n //Base transaction gas
+                    + 2_600n //extcodesize() gas cost
+                    + callIntrinsicCost //intrinsic cost of the CALL opcode
+                    - (value>0n ? 2300n : 0n) //Forwarded gas stipend of 2300 gas
+                    + (gasLimit * 64n / 63n); //Required gas to be forwarded for contract to succeed
+                let topValue = (bottomValue * 33n / 32n) + 6_000n; //Additional buffer
+
+                while (bottomValue <= topValue) {
+                    const mid = (bottomValue + topValue) / 2n;
+                    const success = await attemptCall(to, data, mid);
+
+                    if (success) {
+                        //Still success, we can decrease the top value
+                        topValue = mid - 1n;
+                    } else {
+                        //Not successful, gas needs to be increased
+                        bottomValue = mid + 1n;
+                    }
+                }
+
+                //Extract minimum required tx gas for the gasleft() test to be passed
+                const minimumRequiredTxGas = bottomValue;
+                //Double-check that minimum required tx gas indeed leads to successful tx
+                assert.isTrue(await attemptCall(to, data, minimumRequiredTxGas, true));
+                //One less gas and it fails
+                assert.isFalse(await attemptCall(to, data, minimumRequiredTxGas - 1n, true));
+
+                return minimumRequiredTxGas;
+            }
+
+            const calls = [];
+
+            for(let i = value===0n ? 95 : 200; i<1000; i+=100) {
+                calls.push({...await dummyContract.burnVariableCycles.populateTransaction(i), gasLimit: 150n + BigInt(i)*35n});
+            }
+            for(let i = 1000; i<10000; i+=1000) {
+                calls.push({...await dummyContract.burnVariableCycles.populateTransaction(i), gasLimit: 150n + BigInt(i)*35n});
+            }
+            for(let i = 10000; i<100000; i+=10000) {
+                calls.push({...await dummyContract.burnVariableCycles.populateTransaction(i), gasLimit: 150n + BigInt(i)*35n});
+            }
+            for(let i = 100000; i<500000; i+=100000) {
+                calls.push({...await dummyContract.burnVariableCycles.populateTransaction(i), gasLimit: 150n + BigInt(i)*35n});
+            }
+
+            for(let call of calls) {
+                //This is the absolute minimum gas that the tx needs to still pass the
+                // internal gasleft() check, one less gas will make the tx revert 
+                const minimumRequiredTxGas = await binarySearchMinimumTxGas(call.to, call.data, call.gasLimit);
+                
+                const result = await contract["safeCallNoEmit(address,uint256,bytes)"](
+                    //Have to use random addresses with no zero bytes, such that
+                    // the calldata gas cost stays the same
+                    call.to,
+                    value,
+                    call.data,
+                    {
+                        gasLimit: minimumRequiredTxGas
+                    }
+                );
+
+                //Now we want to check that the gas forwarded to the other contract is indeed
+                // equal to the `gasLimit`
+                //Get the tx trace
+                const trace = await hre.ethers.provider.send("debug_traceTransaction", [result.hash, {disableMemory: true, disableStack: true, disableStorage: true}]);
+                //Get the frame index of the first CALL opcode
+                const callFrameIndex = trace.structLogs.findIndex((val: any) => val.op==="CALL");
+                const callFrame = trace.structLogs[callFrameIndex];
+                //Next frame is the first opcode of the called contract
+                const nextFrame = trace.structLogs[callFrameIndex+1];
+                //Check if that really is the case by checking the depth
+                assert.strictEqual(nextFrame.depth, 2, "Invalid post-call trace frame!");
+
+                const returnFrame = trace.structLogs.find((val: any, index: number) => val.depth===1 && index>callFrameIndex);
+                const gasLeftAfterIntrinsicCosts = BigInt(callFrame.gas) - callIntrinsicCost;
+                const gasAfterCall = BigInt(returnFrame.gas);
+                const gasSpent = gasLeftAfterIntrinsicCosts - gasAfterCall;
+
+                assert.isTrue(gasSpent < ((gasLeftAfterIntrinsicCosts * 63n / 64n) - 10n), "Forwarded gas is too close to the 63/64 of the remaining gas");
+            }
+        }
+
+        //Make sure contract has enough balance
+        await account1.sendTransaction({to: await contract.getAddress(), value: 1_000_000_000n});
+
+        //Check consistency when calling existing contract without amount
+        console.log("Consistency value=0, this might take a while...");
+        await checkConsistency(0n);
+        //Check consistency when calling existing contract with amount
+        console.log("Consistency value>0, this might take a while...");
+        await checkConsistency(1_000n);
+    }).timeout(10*60*1000);
+});


### PR DESCRIPTION
This PR adds the `ContractCallUtils.sol` file, which ensures that calls where the reverts are not bubbled up are handled safely.

The way that regular calls are handled by EVM are very odd, and this is manifested in 2 cases:

### 1. Calling an external contract with explicit gas amount to be forwarded

If you execute the regular call in Solidity, with `target.call{gas: x}()`, the EVM only guarantees that at most `x` gas is gonna be passed down to the called contract. A malicious actor can intentionally use low gas limit for the whole transaction, such that when the external call is attempted the execution context doesn't contain enough gas for `x` gas to be forwarded to the callee, so a lower amount is forwarded, potentially resulting in the called contract running out of gas and failing. This itself wouldn't be a problem, because if the called contract burns through all the gas there is none left for the caller to continue execution. However, because of EIP-150 only 63/64 (~98.5%) of the current gas is forwarded in the call, this opens up possible attack vectors, where 63/64 of the gas is not enough for the called contract to finish execution, but 1/64 (1.5%) of the gas that is left is still enough for the caller to continue executing.

Due to this a sophisticated attacker can execute a gas-dependent branching attack, making calls fail (out of gas) that would otherwise succeed and maliciously accessing execution paths that should happen only if there is an actual genuine revertion in the called contract.

#### Example

```solidity
    function _execute(
        address token, uint256 value, ExecutionAction calldata executionAction, address tokensDestination
    ) internal returns (bool success, bytes memory callError) {
        ....
        //Try to execute calls
        (success, callError) = address(executionProxy).call{gas: executionAction.gasLimit}(
            abi.encodeWithSelector(ExecutionProxy.execute.selector, executionAction.calls)
        );
        ....
    }
```

One such vulnerable example is the execution contract, where users specify the gas limit at which the calls should be executed on their behalf. This is exposed in the `_execute()` function inside `Executor.sol` file.

What could happen, is that a user schedules a set of contract calls and adds a 5M gas limit to it. A malicious executor can come in and trigger the execution with just 2M gas limit for the whole transaction, this will make the actual action fail (since there is only 40% of the expected gas available), but because of the EIP150 rule, the execution would still continue since 30k gas (~1.5% of the 2M) is still enough for the execution contract to finish execution.

#### Fix

A `safeCall(uint256,uint256,bytes,uint256)` function was added in the `ContractCallUtils.sol`, this function asserts that there is for sure enough gas available before executing the call, taking into consideration the variable cost of the `CALL` opcode itself and the EIP150 63/64 rule. This function is then used in all places where calls with a fixed gas and manual revertion handling were used.

### 2. Calling an external contract while forwarding all the remaining gas

Executing the `target.call()` in EVM, doesn't forward all the remaining gas to the called contract - because of the EIP150 rule only 63/64 of the remaining gas is forwarded. This can again open up malicious gas-dependent branching attacks, where an attacker intentionally uses a low transaction gasLimit to make some outside calls fail, while the caller contract continues execution.

#### Example

```solidity
    function claim(address owner, uint96 vaultId, SpvVaultParameters calldata vaultParams, bytes memory transaction, StoredBlockHeader memory blockheader, bytes32[] calldata merkleProof, uint256 position) external {
        ...
        if(frontingAddress != address(0x0)) {
            ...
        } else {
            if(txData.executionHash == bytes32(0x0)) {
                //We can use uncheckedAddUint64, since all sums will surely be in the uint64 range, because of the prior txData.getFullAmounts() call
                (uint256 payoutAmount0, uint256 payoutAmount1) = vaultParams.fromRaw(
                    txData.amount0.uncheckedAddUint64(txData.executionHandlerFeeAmount0), 
                    txData.amount1
                );
                
                //Use non-reverting transfer function, since we also support paying out native currency (ETH), the transfer out can
                // fail if the destination is a malicious contract that e.g. runs out of gas when called, or doesn't allow native
                // currency deposits at all. We silently ignore this error if it happens.
                _transferOutNoRevert(recipient, vaultParams.token0, payoutAmount0, vaultParams.token1, payoutAmount1);
             } else {
                 ...
             }
         }

        //Emit event
        emit Events.Claimed(packedAddressAndVaultId, recipient, btcTxHash, msg.sender, txData.executionHash, frontingAddress, withdrawCount, amount0Raw, amount1Raw);
    }
```

This could theoretically be exploited from the `claim()` function of the spv vault manager. Not practically though as event emitting requires quite some gas here (~3.5k gas) - would only be insecure if the gas required to call `transfer()` function were >~224k gas (such that 1/64 of the gas would enough to emit the event -> 3.5k gas).

Here a malicious caller could execute the ERC20 `transfer()` function with not enough gas, such that the function runs out of gas, but instead of reverting the result is ignored - this is a design decision required by the spv vault, as to not introduce a possibility for the vault to get frozen if there is some issue with the transfer. This means that the user which should've received the ERC20 tokens, doesn't receive anything and the funds are frozen forever in the spv vault contract.

#### Fix

A `safeCall(uint256,uint256,bytes)` function was added in the `ContractCallUtils.sol`, this function forwards all the possible gas (63/64 of the current gas), and ensures that the called function didn't consume it fully before returning. This catches attempts where the called function would burn through all the its available gas and reverts in such cases. It is implemented by sampling the `gasleft()` before the call and directly after the call and then asserting that the post-call gas left (minus the intrinsic cost of the CALL opcode and some small overhead) is at least 1/32 (~3%) of the original gas (this is to make sure that the check triggers before the actual 1/64 would), if such condition is detected the execution is reverted. In case of revertion (because the gas left is not 1/32), an honest actor can easily attempt to execute the same call again by specifying slightly higher gas limit for the transaction (which will then pass the 1/32 limit).

Extra care must be taken as this doesn't provide any protection against contracts which burn unlimited gas (like unbounded loops) - and such calls will always revert (without the possibility to catch the revertion). From the dev perspective the `safeCall(uint256,uint256,bytes)` is similar to external contract calls in Cairo language, which always forwards the full available gas.

---

Relevent contract changes were implemented in:
- [37f6565](https://github.com/atomiqlabs/atomiq-contracts-evm/pull/5/commits/37f6565c7ec75851d731519186ece5cceafdbadf) - ContractCallUtils.sol created
- [cde3829](https://github.com/atomiqlabs/atomiq-contracts-evm/pull/5/commits/cde3829da88bd74e5fb81146b4b9961440aad2c6) - ContractCallUtils used in the codebase, where necessary